### PR TITLE
Restore mistakenly removed out.println() statement to actually write the

### DIFF
--- a/metadata-mgmt/src/main/java/com/redhat/lightblue/applications/LightblueRestRequest.java
+++ b/metadata-mgmt/src/main/java/com/redhat/lightblue/applications/LightblueRestRequest.java
@@ -87,6 +87,7 @@ public class LightblueRestRequest extends HttpServlet implements Servlet {
                 try (CloseableHttpResponse httpResponse = httpClient.execute(httpOperation)) {
                     HttpEntity entity = httpResponse.getEntity();
                     LOGGER.debug("Response received from service" + EntityUtils.toString(entity));
+                    out.println(EntityUtils.toString(entity));
                 }
             }
         } catch (RuntimeException e) {


### PR DESCRIPTION
response to the servlet output.  This statement was mistakely removed a few weeks ago.
