### PR TITLE
Fix read from closed input stream

### DIFF
--- a/metadata-mgmt/src/main/java/com/redhat/lightblue/applications/LightblueRestRequest.java
+++ b/metadata-mgmt/src/main/java/com/redhat/lightblue/applications/LightblueRestRequest.java
@@ -86,8 +86,9 @@ public class LightblueRestRequest extends HttpServlet implements Servlet {
                 
                 try (CloseableHttpResponse httpResponse = httpClient.execute(httpOperation)) {
                     HttpEntity entity = httpResponse.getEntity();
-                    LOGGER.debug("Response received from service" + EntityUtils.toString(entity));
-                    out.println(EntityUtils.toString(entity));
+                    String serviceResponse = EntityUtils.toString(entity);
+                    LOGGER.debug("Response received from service" + serviceResponse);
+                    out.println(serviceResponse);
                 }
             }
         } catch (RuntimeException e) {


### PR DESCRIPTION
Apparently EntityUtils.toString consumes the entity's content stream, and calling twice results in error
