### PR TITLE
Marked jboss-javaee-6.0 dependency as provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
                 <artifactId>jboss-javaee-6.0</artifactId>
                 <version>3.0.2.Final</version>
                 <type>pom</type>
+                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <artifactId>xalan</artifactId>


### PR DESCRIPTION
We deploy on jboss so makes no sense to bundle these, unless we don't trust the right version to be bundled.  Needs to be deployed to test it for sure.  Reduces war and therefore rpm sizes by removing unnecessary dependencies.
