### PR TITLE
Properly destroy lbJsonEditor element

### DIFF
--- a/data-mgmt/src/main/webapp/js/directives.js
+++ b/data-mgmt/src/main/webapp/js/directives.js
@@ -92,6 +92,11 @@ dataManageDirectives.directive("lbJsonEditor", ["util", function(util) {
             element.triggerHandler("blur");
           });
         }
+
+        element.on("$destroy", function() {
+          aceEditor.session.$stopWorker();
+          aceEditor.destroy();
+        });
       }
 
       function trySetViewValue() {


### PR DESCRIPTION
Fixes #33 

Prevents a memleak when switching operations (find,insert,etc.)
