### PR TITLE
Reenable SAML signature validation

### DIFF
--- a/metadata-mgmt-saml-auth/src/main/webapp/WEB-INF/picketlink.xml
+++ b/metadata-mgmt-saml-auth/src/main/webapp/WEB-INF/picketlink.xml
@@ -1,6 +1,6 @@
 <!-- Keys in this file are defined as system properties in stadanlone.xml -->
 <PicketLink xmlns="urn:picketlink:identity-federation:config:2.1">
-    <PicketLinkSP xmlns="urn:picketlink:identity-federation:config:1.0" ServerEnvironment="tomcat" BindingType="POST" SupportsSignatures="false">
+    <PicketLinkSP xmlns="urn:picketlink:identity-federation:config:1.0" ServerEnvironment="tomcat" BindingType="POST" SupportsSignatures="true">
         <IdentityURL>${IdentityURL}</IdentityURL>
         <ServiceURL>${ServiceURL}</ServiceURL>
         <KeyProvider ClassName="org.picketlink.identity.federation.core.impl.KeyStoreKeyManager">


### PR DESCRIPTION
Not sure why I turned this off back in August, but now it is re-enabled