### PR TITLE
Remove link from 'Lightblue Data Management' in navbar (fixes #68)

### DIFF
--- a/data-mgmt/src/main/webapp/index.html
+++ b/data-mgmt/src/main/webapp/index.html
@@ -38,7 +38,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="#">Lightblue Data Management</a>
+          <p class="navbar-brand">Lightblue Data Management</p>
         </div><!--/.navbar-header -->
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav">


### PR DESCRIPTION
Minor usability improvement, since this link just causes the app to reload, which disrupts the feel of a single-page app, and (perhaps until #85 is addressed) makes you have to select an environment again.

So I think it makes sense just to remove the link.