### PR TITLE
Remove debug logging

### DIFF
--- a/data-mgmt/src/main/webapp/js/controllers.js
+++ b/data-mgmt/src/main/webapp/js/controllers.js
@@ -212,8 +212,6 @@ var dataManageControllers = angular.module("dataManageControllers", ["dataManage
           }
 
           function setRequestRaw(requestBody) {
-            console.log("setRequestRaw");
-
             var oldObjectType = $scope.request.body.objectType;
             $scope.request.body.objectType = getOrDefault(requestBody, "objectType");
 

--- a/data-mgmt/src/main/webapp/js/directives.js
+++ b/data-mgmt/src/main/webapp/js/directives.js
@@ -50,8 +50,6 @@ dataManageDirectives.directive("lbJsonEditor", ["util", function(util) {
             return;
           }
 
-          console.log("change", attributes.ngModel);
-
           if (util.arrayContains(updateOn, "default") || 
             util.arrayContains(updateOn, "change")) {
 
@@ -122,7 +120,6 @@ dataManageDirectives.directive("lbJsonEditor", ["util", function(util) {
 
         // TODO: deal with triggering change event, which redundantly sets view 
         // value on model
-        console.log("editor.set", attributes.ngModel);
         editor.set(newValue);
 
         // Editor in tree mode collapses nodes on call to `set`... expand them.


### PR DESCRIPTION
In the future it would be helpful to take advantage of angular's $log service but until then these messages are just console clutter.