### PR TITLE
Updated client to latest snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
             <dependency>
                 <groupId>com.redhat.lightblue.client</groupId>
                 <artifactId>lightblue-client-http</artifactId>
-                <version>1.8.0-SNAPSHOT</version>
+                <version>2.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>


### PR DESCRIPTION
Surprised this worked locally, doing a PR to be sure...
Found after removing local lightblue artifacts and trying a local build of https://github.com/lightblue-platform/lightblue with -o this old version was hanging out.